### PR TITLE
TreeSat multilabel fixes + default num_timesteps value for CropHarvestMultiClassValidation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ wandb
 gha-creds-*.json
 # images need to be explicitly added
 *.png
+.idea

--- a/eval.py
+++ b/eval.py
@@ -75,6 +75,6 @@ for eval_task in tqdm(eval_task_list, desc="Full Evaluation"):
     print("\n" + eval_task.name, flush=True)
 
     results = eval_task.finetuning_results(model, model_modes=model_modes)
-    print(results, flush=True)
+    print(json.dumps(results, indent=2), flush=True)
 
     eval_task.clear_data()

--- a/presto/eval/algae_blooms_eval.py
+++ b/presto/eval/algae_blooms_eval.py
@@ -34,7 +34,6 @@ SURROUNDING_METRES = 80
 
 
 class AlgaeBloomsEval(EvalDataset):
-
     regression = True
     multilabel = False
     num_outputs = 1
@@ -154,7 +153,6 @@ class AlgaeBloomsEval(EvalDataset):
         pretrained_model=None,
         mask: Optional[np.ndarray] = None,
     ) -> Dict:
-
         batch_size = 64
 
         if isinstance(finetuned_model, BaseEstimator):
@@ -174,7 +172,7 @@ class AlgaeBloomsEval(EvalDataset):
         )
 
         test_preds = []
-        for (x, dw, month, latlons) in dl:
+        for x, dw, month, latlons in dl:
             batch_mask = self._mask_to_batch_tensor(mask, x.shape[0])
             if isinstance(finetuned_model, FineTuningModel):
                 finetuned_model.eval()
@@ -251,7 +249,7 @@ class AlgaeBloomsEval(EvalDataset):
         for _ in tqdm(range(max_epochs), desc="Finetuning"):
             model.train()
             epoch_train_loss = 0.0
-            for (x, dw, target, month, latlons) in tqdm(train_dl, desc="Training", leave=False):
+            for x, dw, target, month, latlons in tqdm(train_dl, desc="Training", leave=False):
                 opt.zero_grad()
                 batch_mask = self._mask_to_batch_tensor(mask, x.shape[0])
                 preds = model(x, dynamic_world=dw, mask=batch_mask, latlons=latlons, month=month)

--- a/presto/eval/algae_blooms_eval.py
+++ b/presto/eval/algae_blooms_eval.py
@@ -36,6 +36,7 @@ SURROUNDING_METRES = 80
 class AlgaeBloomsEval(EvalDataset):
 
     regression = True
+    multilabel = False
     num_outputs = 1
 
     def __init__(self) -> None:

--- a/presto/eval/cropharvest_eval.py
+++ b/presto/eval/cropharvest_eval.py
@@ -57,6 +57,7 @@ def download_cropharvest_data(root: Path = cropharvest_data_dir):
 class CropHarvestEval(EvalDataset):
 
     regression = False
+    multilabel = False
     num_outputs = 1
     start_month = 1
 

--- a/presto/eval/cropharvest_eval.py
+++ b/presto/eval/cropharvest_eval.py
@@ -55,7 +55,6 @@ def download_cropharvest_data(root: Path = cropharvest_data_dir):
 
 
 class CropHarvestEval(EvalDataset):
-
     regression = False
     multilabel = False
     num_outputs = 1
@@ -173,12 +172,10 @@ class CropHarvestEval(EvalDataset):
         pretrained_model=None,
         mask: Optional[np.ndarray] = None,
     ) -> Dict:
-
         if isinstance(finetuned_model, BaseEstimator):
             assert isinstance(pretrained_model, (Mosaiks1d, Seq2Seq))
 
         with tempfile.TemporaryDirectory() as results_dir:
-
             for test_id, test_instance, test_dw_instance in self.dataset.test_data(max_size=10000):
                 savepath = Path(results_dir) / f"{test_id}.nc"
 
@@ -267,7 +264,6 @@ class CropHarvestEval(EvalDataset):
 
 
 class CropHarvestMultiClassValidation(CropHarvestEval):
-
     regression = False
     num_outputs = 10
 
@@ -328,8 +324,7 @@ class CropHarvestMultiClassValidation(CropHarvestEval):
         )
 
         test_preds, test_true = [], []
-        for (x, dw, latlons, y) in dl:
-
+        for x, dw, latlons, y in dl:
             x = S1_S2_ERA5_SRTM.normalize(x).to(device).float()
             b_mask = self._mask_to_batch_tensor(mask, x.shape[0])
 

--- a/presto/eval/cropharvest_eval.py
+++ b/presto/eval/cropharvest_eval.py
@@ -60,6 +60,7 @@ class CropHarvestEval(EvalDataset):
     multilabel = False
     num_outputs = 1
     start_month = 1
+    num_timesteps = None
 
     def __init__(
         self, country: str, ignore_dynamic_world: bool = False, num_timesteps: Optional[int] = None

--- a/presto/eval/eurosat_eval.py
+++ b/presto/eval/eurosat_eval.py
@@ -40,6 +40,7 @@ INDICES_IN_TIF_FILE = list(range(16, 64, 16))
 class EuroSatEval(EvalDataset):
 
     regression = False
+    multilabel = False
     num_outputs = 10
 
     # this is not the true start month!

--- a/presto/eval/eurosat_eval.py
+++ b/presto/eval/eurosat_eval.py
@@ -38,7 +38,6 @@ INDICES_IN_TIF_FILE = list(range(16, 64, 16))
 
 
 class EuroSatEval(EvalDataset):
-
     regression = False
     multilabel = False
     num_outputs = 10
@@ -83,7 +82,6 @@ class EuroSatEval(EvalDataset):
 
     @staticmethod
     def image_to_eo_array(tif_file: Path):
-
         image = xarray.open_rasterio(tif_file)
         # from (e.g.) +init=epsg:32630 to epsg:32630
         crs = image.crs.split("=")[-1]
@@ -231,7 +229,7 @@ class EuroSatEval(EvalDataset):
         )
 
         test_preds = []
-        for (x, dw, latlons) in dl:
+        for x, dw, latlons in dl:
             batch_mask = self._mask_to_batch_tensor(updated_mask, x.shape[0])
             if isinstance(finetuned_model, FineTuningModel):
                 finetuned_model.eval()

--- a/presto/eval/eval.py
+++ b/presto/eval/eval.py
@@ -15,7 +15,6 @@ from .knn import KNNat5, KNNat20, KNNat100
 
 
 class EvalDataset:
-
     name: str
     num_outputs: int
     regression: bool
@@ -36,7 +35,6 @@ class EvalDataset:
         if self.multilabel:
             lr = MultiOutputClassifier(lr, n_jobs=self.num_outputs)
         return lr
-
 
     def finetune(self, pretrained_model, mask: Optional[np.ndarray] = None) -> FineTuningModel:
         raise NotImplementedError
@@ -71,7 +69,6 @@ class EvalDataset:
         batch_size: int = 64,
         models: List[str] = ["Regression", "Random Forest"],
     ) -> Sequence[BaseEstimator]:
-
         for model_mode in models:
             if self.regression:
                 assert model_mode in ["Regression", "Random Forest"]
@@ -100,7 +97,7 @@ class EvalDataset:
             shuffle=False,
         )
 
-        for (x, dw, latlons, month) in dl:
+        for x, dw, latlons, month in dl:
             batch_mask = self._mask_to_batch_tensor(mask, x.shape[0])
             with torch.no_grad():
                 encodings = (

--- a/presto/eval/fuel_moisture_eval.py
+++ b/presto/eval/fuel_moisture_eval.py
@@ -39,6 +39,7 @@ SURROUNDING_METRES = 80
 class FuelMoistureEval(EvalDataset):
 
     regression = True
+    multilabel = False
     num_outputs = 1
 
     def __init__(self) -> None:

--- a/presto/eval/fuel_moisture_eval.py
+++ b/presto/eval/fuel_moisture_eval.py
@@ -37,7 +37,6 @@ SURROUNDING_METRES = 80
 
 
 class FuelMoistureEval(EvalDataset):
-
     regression = True
     multilabel = False
     num_outputs = 1
@@ -177,7 +176,6 @@ class FuelMoistureEval(EvalDataset):
         pretrained_model=None,
         mask: Optional[np.ndarray] = None,
     ) -> Dict:
-
         batch_size = 64
 
         if isinstance(finetuned_model, BaseEstimator):
@@ -197,7 +195,7 @@ class FuelMoistureEval(EvalDataset):
         )
 
         test_preds = []
-        for (x, dw, month, latlons) in dl:
+        for x, dw, month, latlons in dl:
             batch_mask = self._mask_to_batch_tensor(mask, x.shape[0])
             if isinstance(finetuned_model, FineTuningModel):
                 finetuned_model.eval()
@@ -277,7 +275,7 @@ class FuelMoistureEval(EvalDataset):
         for _ in tqdm(range(max_epochs), desc="Finetuning"):
             model.train()
             epoch_train_loss = 0.0
-            for (x, dw, target, month, latlons) in tqdm(train_dl, desc="Training", leave=False):
+            for x, dw, target, month, latlons in tqdm(train_dl, desc="Training", leave=False):
                 opt.zero_grad()
                 batch_mask = self._mask_to_batch_tensor(mask, x.shape[0])
                 preds = model(

--- a/presto/eval/treesat_eval.py
+++ b/presto/eval/treesat_eval.py
@@ -73,6 +73,7 @@ class TreeSatEval(EvalDataset):
     }
 
     regression = False
+    multilabel = True
     # different than the paper but this is
     # from all the unique classes in the labels json
     # (above)
@@ -404,7 +405,7 @@ class TreeSatEval(EvalDataset):
         model = self._construct_finetuning_model(pretrained_model)
 
         opt = Adam(model.parameters(), lr=lr)
-        loss_fn = nn.BCELoss(reduction="mean")
+        loss_fn = nn.BCEWithLogitsLoss(reduction="mean")
 
         x, dw, latlons, target, _ = self.load_npys(test=False)
 

--- a/presto/eval/treesat_eval.py
+++ b/presto/eval/treesat_eval.py
@@ -53,7 +53,6 @@ INDICES_IN_TIF_FILE = list(range(0, 6, 2))
 
 
 class TreeSatEval(EvalDataset):
-
     labels_to_int = {
         "Abies": 0,
         "Acer": 1,
@@ -84,7 +83,6 @@ class TreeSatEval(EvalDataset):
     start_month = 6
 
     def __init__(self, subset: Optional[str] = None) -> None:
-
         if subset is not None:
             assert subset in ["S1", "S2"]
             self.name = f"TreeSatAI_{subset}"
@@ -108,7 +106,6 @@ class TreeSatEval(EvalDataset):
 
     @classmethod
     def image_to_eo_array(cls, tif_file: Path, labels: Dict):
-
         s1_image, class_name = cls.s2_image_path_to_s1_path_and_class(tif_file)
         s2 = xarray.open_rasterio(tif_file)
         s1 = xarray.open_rasterio(s1_image)
@@ -136,7 +133,7 @@ class TreeSatEval(EvalDataset):
 
         labels_np = np.zeros(len(cls.labels_to_int))
         positive_classes = labels[tif_file.name]
-        for (name, percentage) in positive_classes:
+        for name, percentage in positive_classes:
             labels_np[cls.labels_to_int[name]] = percentage
 
         for x_idx in INDICES_IN_TIF_FILE:
@@ -274,7 +271,7 @@ class TreeSatEval(EvalDataset):
         )
 
         test_preds = []
-        for (x, dw, latlons) in dl:
+        for x, dw, latlons in dl:
             batch_mask = self._mask_to_batch_tensor(updated_mask, x.shape[0])
             if isinstance(finetuned_model, FineTuningModel):
                 finetuned_model.eval()


### PR DESCRIPTION
- Added default `num_timesteps` to CropHarvestEval to fix validation while running `train.py`.
The num_timesteps field is not initialized in the `CropHarvestMultiClassValidation` subclass that is used for validation, but the `finetuning_results` method calls `truncate_timesteps` which accesses the field.

- #5 made the TreeSat eval task multilabel, causing the sigmoid in `FinetuningHead` not to be applied anymore. However, TreeSatEval still used pytorch's `BCELoss` which expects inputs to be in [0, 1]. This PR changes TreeSatEval to use `BCEWithLogitsLoss` instead.

- Further regarding TreeSat having been made multilabel: sklearn's [`LogisticRegression`](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LogisticRegression.html#sklearn.linear_model.LogisticRegression.fit) doesn’t support multilabel tasks, its `.fit(X, y)` takes y with shape `(n_samples,)`. See the discussion [here](https://scikit-learn.org/stable/modules/multiclass.html#multioutputclassifier). To keep using logistic regression, I wrapped the estimator in a [`sklearn.multioutput.MultiOutputClassifier`](https://scikit-learn.org/stable/modules/generated/sklearn.multioutput.MultiOutputClassifier.html) which will fit one classifier per target.