### PR TITLE
Move presto pretrained model to the right device

### DIFF
--- a/presto/presto.py
+++ b/presto/presto.py
@@ -789,4 +789,4 @@ class Presto(Seq2Seq):
     def load_pretrained(cls, model_path: Union[str, Path] = default_model_path):
         model = cls.construct()
         model.load_state_dict(torch.load(model_path, map_location=device))
-        return model
+        return model.to(device)


### PR DESCRIPTION
Addresses #29 

@mkondratyev85, thank you for raising this issue, and for #30. 

I'd prefer to avoid moving model parameters to the device, and move the entire model object around if possible - does this fix your problem?