### PR TITLE
Add construct_batch_presto_input

### DIFF
--- a/presto/__init__.py
+++ b/presto/__init__.py
@@ -1,4 +1,9 @@
-from .dataops.utils import construct_single_presto_input
+from .dataops.utils import construct_batch_presto_input, construct_single_presto_input
 from .presto import Presto, PrestoFineTuningModel
 
-__all__ = ["Presto", "PrestoFineTuningModel", "construct_single_presto_input"]
+__all__ = [
+    "Presto",
+    "PrestoFineTuningModel",
+    "construct_single_presto_input",
+    "construct_batch_presto_input",
+]

--- a/presto/dataops/utils.py
+++ b/presto/dataops/utils.py
@@ -135,9 +135,9 @@ def construct_batch_presto_input(
     # all inputs must agree on (batch_size, num_timesteps)
     batch_size = inputs[0].shape[0]
     num_timesteps = inputs[0].shape[1]
-    for data in inputs:
-        assert data.shape[0] == batch_size, "All inputs must share the same batch size"
-        assert data.shape[1] == num_timesteps, "All inputs must share the same number of timesteps"
+    for inp in inputs:
+        assert inp.shape[0] == batch_size, "All inputs must share the same batch size"
+        assert inp.shape[1] == num_timesteps, "All inputs must share the same number of timesteps"
 
     mask = torch.ones(batch_size, num_timesteps, len(BANDS))
     x = torch.zeros(batch_size, num_timesteps, len(BANDS))

--- a/presto/dataops/utils.py
+++ b/presto/dataops/utils.py
@@ -91,3 +91,93 @@ def construct_single_presto_input(
     else:
         x = x[:, keep_indices]
     return x, mask, dynamic_world
+
+
+def construct_batch_presto_input(
+    s1: Optional[torch.Tensor] = None,
+    s1_bands: Optional[List[str]] = None,
+    s2: Optional[torch.Tensor] = None,
+    s2_bands: Optional[List[str]] = None,
+    era5: Optional[torch.Tensor] = None,
+    era5_bands: Optional[List[str]] = None,
+    srtm: Optional[torch.Tensor] = None,
+    srtm_bands: Optional[List[str]] = None,
+    dynamic_world: Optional[torch.Tensor] = None,
+    normalize: bool = True,
+):
+    """
+    A batched version of `construct_single_presto_input`.
+
+    Inputs are paired into a tensor input <X> and a list <X>_bands, which describes <X>.
+
+    <X> should have shape (batch_size, num_timesteps, len(<X>_bands)), with the following bands
+    possible for each input:
+
+    s1: ["VV", "VH"]
+    s2: ["B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B8A", "B9", "B10", "B11", "B12"]
+    era5: ["temperature_2m", "total_precipitation"]
+        "temperature_2m": Temperature of air at 2m above the surface of land,
+            sea or in-land waters in Kelvin (K)
+        "total_precipitation": Accumulated liquid and frozen water, including rain and snow,
+            that falls to the Earth's surface. Measured in metres (m)
+    srtm: ["elevation", "slope"]
+
+    dynamic_world is a 2d input of shape (batch_size, num_timesteps) representing the dynamic
+        world classes of each timestep for each pixel in the batch.
+
+    Returns x, mask and dynamic_world, each with a leading batch dimension.
+    """
+    inputs = [x for x in [s1, s2, era5, srtm] if x is not None]
+    if dynamic_world is not None:
+        inputs.append(dynamic_world)
+    assert len(inputs) > 0, "At least one input must be provided"
+
+    # all inputs must agree on (batch_size, num_timesteps)
+    batch_size = inputs[0].shape[0]
+    num_timesteps = inputs[0].shape[1]
+    for data in inputs:
+        assert data.shape[0] == batch_size, "All inputs must share the same batch size"
+        assert data.shape[1] == num_timesteps, "All inputs must share the same number of timesteps"
+
+    mask = torch.ones(batch_size, num_timesteps, len(BANDS))
+    x = torch.zeros(batch_size, num_timesteps, len(BANDS))
+
+    for band_group in [
+        (s1, s1_bands, S1_BANDS),
+        (s2, s2_bands, S2_BANDS),
+        (era5, era5_bands, ERA5_BANDS),
+        (srtm, srtm_bands, SRTM_BANDS),
+    ]:
+        data, input_bands, output_bands = band_group
+        if data is not None:
+            assert input_bands is not None
+        else:
+            continue
+
+        kept_output_bands = [x for x in output_bands if x not in REMOVED_BANDS]
+        # construct a mapping from the input bands to the expected bands
+        kept_input_band_idxs = [i for i, val in enumerate(input_bands) if val in kept_output_bands]
+        kept_input_band_names = [val for val in input_bands if val in kept_output_bands]
+
+        input_to_output_mapping = [BANDS.index(val) for val in kept_input_band_names]
+
+        x[:, :, input_to_output_mapping] = data[:, :, kept_input_band_idxs]
+        mask[:, :, input_to_output_mapping] = 0
+
+    if dynamic_world is None:
+        dynamic_world = torch.ones(batch_size, num_timesteps) * (
+            DynamicWorld2020_2021.class_amount
+        )
+
+    keep_indices = [idx for idx, val in enumerate(BANDS) if val != "B9"]
+    mask = mask[:, :, keep_indices]
+
+    if normalize:
+        # normalize includes x = x[:, :, keep_indices]
+        x = S1_S2_ERA5_SRTM.normalize(x)
+        if s2_bands is not None:
+            if ("B8" in s2_bands) and ("B4" in s2_bands):
+                mask[:, :, NORMED_BANDS.index("NDVI")] = 0
+    else:
+        x = x[:, :, keep_indices]
+    return x, mask, dynamic_world

--- a/tests/test_dataops_utils.py
+++ b/tests/test_dataops_utils.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 
 import torch
 
-from presto import construct_single_presto_input
+from presto import construct_batch_presto_input, construct_single_presto_input
 from presto.dataops.pipelines.dynamicworld import DynamicWorld2020_2021
 from presto.dataops.pipelines.s1_s2_era5_srtm import NORMED_BANDS
 
@@ -40,3 +40,45 @@ class TestDatopsUtils(TestCase):
         for idx, band in enumerate(NORMED_BANDS):
             if band in input_bands + ["NDVI"]:
                 self.assertTrue((mask[:, idx] == 0).all())
+
+    def test_construct_batch_presto_input(self):
+        input_bands = ["B2", "B3", "B4", "B8"]
+        batch_size, num_timesteps = 3, 2
+        x, mask, dw = construct_batch_presto_input(
+            s2=torch.ones(batch_size, num_timesteps, len(input_bands)),
+            s2_bands=input_bands,
+            normalize=False,
+        )
+        self.assertEqual(x.shape[0], batch_size)
+        self.assertEqual(mask.shape[0], batch_size)
+        self.assertEqual(dw.shape, (batch_size, num_timesteps))
+        self.assertTrue(torch.equal(dw, torch.ones_like(dw) * DynamicWorld2020_2021.class_amount))
+        self.assertEqual(x.shape, mask.shape)
+        self.assertTrue((x[mask == 1] == 0).all())
+        self.assertTrue((x[mask == 0] != 0).all())
+        for idx, band in enumerate(NORMED_BANDS):
+            if band in input_bands:
+                self.assertTrue((mask[:, :, idx] == 0).all())
+            else:
+                self.assertTrue((mask[:, :, idx] == 1).all())
+
+    def test_construct_batch_matches_single(self):
+        # a batch built from stacked single inputs should match the per-item outputs
+        input_bands = ["B2", "B3", "B4", "B8"]
+        item_a = torch.tensor([[1, 2, 3, 4], [5, 6, 7, 8]]).float()
+        item_b = torch.tensor([[2, 4, 6, 8], [1, 3, 5, 7]]).float()
+
+        xa, ma, dwa = construct_single_presto_input(
+            s2=item_a, s2_bands=input_bands, normalize=True
+        )
+        xb, mb, dwb = construct_single_presto_input(
+            s2=item_b, s2_bands=input_bands, normalize=True
+        )
+
+        x, mask, dw = construct_batch_presto_input(
+            s2=torch.stack([item_a, item_b]), s2_bands=input_bands, normalize=True
+        )
+
+        self.assertTrue(torch.allclose(x, torch.stack([xa, xb])))
+        self.assertTrue(torch.equal(mask, torch.stack([ma, mb])))
+        self.assertTrue(torch.equal(dw, torch.stack([dwa, dwb])))


### PR DESCRIPTION
Adds a batched alternative to construct_single_presto_input that accepts a leading batch dimension, with tests verifying it matches the single-input path.